### PR TITLE
Add app_options parameter to pass arbitrary options to gatttool

### DIFF
--- a/pygatt/classes.py
+++ b/pygatt/classes.py
@@ -183,7 +183,7 @@ class BluetoothLEDevice(object):
 
             self.logger.debug('Sent cmd=%s', cmd)
 
-    def char_read_uuid(self, uuid):
+    def char_read_uuid(self, uuid, timeout=pygatt.constants.DEFAULT_TIMEOUT_S):
         """
         Reads a Characteristic by UUID.
 
@@ -194,13 +194,14 @@ class BluetoothLEDevice(object):
         """
         with self.connection_lock:
             self.con.sendline('char-read-uuid %s' % uuid)
-            self._expect('value: .*? \r')
+            self._expect('value: .*? \r', timeout)
 
             rval = self.con.after.split()[1:]
 
             return bytearray([int(x, 16) for x in rval])
 
-    def char_read_hnd(self, handle):
+    def char_read_hnd(self, handle,
+                      timeout=pygatt.constants.DEFAULT_TIMEOUT_S):
         """
         Reads a Characteristic by Handle.
 
@@ -211,7 +212,7 @@ class BluetoothLEDevice(object):
         """
         with self.connection_lock:
             self.con.sendline('char-read-hnd 0x%02x' % handle)
-            self._expect('descriptor: .*?\r')
+            self._expect('descriptor: .*?\r', timeout)
 
             rval = self.con.after.split()[1:]
 

--- a/pygatt/classes.py
+++ b/pygatt/classes.py
@@ -38,7 +38,7 @@ class BluetoothLEDevice(object):
     logger.addHandler(console_handler)
     logger.propagate = False
 
-    def __init__(self, mac_address, hci_device='hci0'):
+    def __init__(self, mac_address, hci_device='hci0', app_options=''):
         self.handles = {}
         self.subscribed_handlers = {}
 
@@ -50,6 +50,7 @@ class BluetoothLEDevice(object):
 
         gatttool_cmd = ' '.join([
             'gatttool',
+            app_options,
             '-b',
             mac_address,
             '-i',

--- a/pygatt/classes.py
+++ b/pygatt/classes.py
@@ -48,7 +48,7 @@ class BluetoothLEDevice(object):
 
         self.connection_lock = threading.RLock()
 
-        gatttool_cmd = ' '.join([
+        gatttool_cmd = ' '.join(filter(None, [
             'gatttool',
             app_options,
             '-b',
@@ -56,7 +56,7 @@ class BluetoothLEDevice(object):
             '-i',
             hci_device,
             '-I'
-        ])
+        ]))
 
         self.logger.debug('gatttool_cmd=%s', gatttool_cmd)
         self.con = pexpect.spawn(gatttool_cmd)

--- a/pygatt/classes.py
+++ b/pygatt/classes.py
@@ -95,6 +95,11 @@ class BluetoothLEDevice(object):
             raise pygatt.exceptions.BluetoothLEError(
                 "Timed-out connecting to device after %s seconds." % timeout)
 
+    def disconnect(self):
+        """Send gatttool disconnect command"""
+        self.logger.info('Disconnecting...')
+        self.con.sendline('disconnect')
+
     def get_handle(self, uuid):
         """
         Look up and return the handle for an attribute by its UUID.

--- a/pygatt/util.py
+++ b/pygatt/util.py
@@ -58,10 +58,15 @@ def lescan(timeout=5, use_sudo=True):
                 r'(([0-9A-Fa-f][0-9A-Fa-f]:?){6}) (\(?[\w]+\)?)', line)
 
             if match is not None:
-                name = match.group(1)
-                devices[name] = {
-                    'address': match.group(1),
-                    'name': match.group(3)
-                }
+                mac = match.group(1)
+                name = match.group(3)
+
+                if mac in devices and name != '(unknown)':
+                    devices[mac]['name'] = name
+                elif mac not in devices:
+                    devices[mac] = {
+                        'address': mac,
+                        'name': name
+                    }
 
     return [device for device in devices.values()]


### PR DESCRIPTION
I added a parameter to the BluetoothLEDevice **init** so you can pass arbitrary options to gatttool. My nordic nrf51 won't connect at all unless i pass "-t random" so this was necessary for me. It might  help others. 
